### PR TITLE
Remove --use-wheel from pip usage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,10 +25,10 @@ built packages::
         pip wheel --wheel-dir=/tmp/wheelhouse pyramid
 
         # Install from cached wheels
-        pip install --use-wheel --no-index --find-links=/tmp/wheelhouse pyramid
+        pip install --only-binary=:all: --no-index --find-links=/tmp/wheelhouse pyramid
 
         # Install from cached wheels remotely
-        pip install --use-wheel --no-index --find-links=https://wheelhouse.example.com/ pyramid
+        pip install --only-binary=:all: --no-index --find-links=https://wheelhouse.example.com/ pyramid
 
 
 For lxml, an up to 3-minute "search for the newest version and compile"


### PR DESCRIPTION
This has been removed in pip version 10 in favour of --no-binary and --only-binary.